### PR TITLE
Fix GPU device removed (DXGI_ERROR_DEVICE_REMOVED) crash loop

### DIFF
--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -37,6 +37,9 @@ local HasPetUI = HasPetUI
 local GetPetHappiness = GetPetHappiness
 local GetPetActionInfo = GetPetActionInfo
 local UnitIsTrivial = UnitIsTrivial
+local CharacterFrame = CharacterFrame
+local SpellBookFrame = SpellBookFrame
+local FriendsFrame = FriendsFrame
 
 --------------------------------------------------------------------------------
 -- Bit Cache Storage
@@ -110,6 +113,10 @@ local bits3Cache = {
     chatInputActive = false,        -- bit 9 (polled)
     softTargetEnabled = false,      -- bit 10
     mailFrameShown = false,         -- bit 11
+    anyBagOpen = false,             -- bit 12 (event-driven: BAG_OPEN/BAG_CLOSED)
+    characterFrameOpen = false,     -- bit 13 (hooked)
+    spellBookFrameOpen = false,     -- bit 14 (hooked)
+    friendsFrameOpen = false,       -- bit 15 (hooked)
 }
 
 -- Track if cache has been initialized
@@ -409,6 +416,11 @@ local function InitializeCache()
     UpdateLootFrameCache()
     UpdateMailFrameCache()
 
+    bits3Cache.anyBagOpen = DataToColor:AnyBagOpen()
+    bits3Cache.characterFrameOpen = DataToColor:CharacterFrameOpen()
+    bits3Cache.spellBookFrameOpen = DataToColor:SpellBookFrameOpen()
+    bits3Cache.friendsFrameOpen = DataToColor:FriendsFrameOpen()
+
     -- Initialize polled values (includes UpdateSpellStateCache)
     UpdatePolledValues()
 
@@ -503,7 +515,11 @@ function DataToColor:Bits3Cached()
         (bits3Cache.lootFrameShown and 2 or 0) ^ 8 +
         (bits3Cache.chatInputActive and 2 or 0) ^ 9 +
         (bits3Cache.softTargetEnabled and 2 or 0) ^ 10 +
-        (bits3Cache.mailFrameShown and 2 or 0) ^ 11
+        (bits3Cache.mailFrameShown and 2 or 0) ^ 11 +
+        (bits3Cache.anyBagOpen and 2 or 0) ^ 12 +
+        (bits3Cache.characterFrameOpen and 2 or 0) ^ 13 +
+        (bits3Cache.spellBookFrameOpen and 2 or 0) ^ 14 +
+        (bits3Cache.friendsFrameOpen and 2 or 0) ^ 15
 end
 
 --------------------------------------------------------------------------------
@@ -514,13 +530,42 @@ end
 
 local cacheInitializedOnce = false
 
+local function HookFrameVisibility()
+    if CharacterFrame then
+        CharacterFrame:HookScript("OnShow", function()
+            bits3Cache.characterFrameOpen = true
+        end)
+        CharacterFrame:HookScript("OnHide", function()
+            bits3Cache.characterFrameOpen = false
+        end)
+    end
+
+    if SpellBookFrame then
+        SpellBookFrame:HookScript("OnShow", function()
+            bits3Cache.spellBookFrameOpen = true
+        end)
+        SpellBookFrame:HookScript("OnHide", function()
+            bits3Cache.spellBookFrameOpen = false
+        end)
+    end
+
+    if FriendsFrame then
+        FriendsFrame:HookScript("OnShow", function()
+            bits3Cache.friendsFrameOpen = true
+        end)
+        FriendsFrame:HookScript("OnHide", function()
+            bits3Cache.friendsFrameOpen = false
+        end)
+    end
+end
+
 function DataToColor:RegisterBitCacheEvents()
     -- Initialize cache (events are registered in EventHandlers.lua)
     InitializeCache()
 
     if not cacheInitializedOnce then
         cacheInitializedOnce = true
-        --DataToColor:Print("BitCache initialized - event-driven caching enabled")
+        HookFrameVisibility()
     end
 end
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.7
+## Version: 1.9.8
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.7
+## Version: 1.9.8
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.7
+## Version: 1.9.8
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -179,6 +179,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('LOOT_OPENED', 'OnLootOpened_BitCache')
     DataToColor:RegisterEvent('MAIL_SHOW', 'OnMailShow_BitCache')
     DataToColor:RegisterEvent('MAIL_CLOSED', 'OnMailClosed_BitCache')
+    DataToColor:RegisterEvent('BAG_OPEN', 'OnBagOpen_BitCache')
 
     -- Classic-only events
     if DataToColor:IsClassicPreCata() then
@@ -642,6 +643,11 @@ function DataToColor:OnBagUpdate(event, containerID)
             DataToColor.equipmentQueue:push(invID)
         end
     end
+
+    -- Update BitCache on bag close (recheck since other bags may still be open)
+    if event == "BAG_CLOSED" and DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.anyBagOpen = DataToColor:AnyBagOpen()
+    end
     --DataToColor:Print("OnBagUpdate "..containerID)
 end
 
@@ -1057,5 +1063,11 @@ end
 function DataToColor:OnMailClosed_BitCache(event)
     if DataToColor.BitCache and DataToColor.BitCache.bits3 then
         DataToColor.BitCache.bits3.mailFrameShown = false
+    end
+end
+
+function DataToColor:OnBagOpen_BitCache(event, containerID)
+    if DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.anyBagOpen = true
     end
 end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -57,6 +57,10 @@ local GameMenuFrame = GameMenuFrame
 local LootFrame = LootFrame
 local ChatEdit_GetActiveWindow = ChatEdit_GetActiveWindow
 local MailFrame = MailFrame
+local IsBagOpen = IsBagOpen
+local CharacterFrame = CharacterFrame
+local SpellBookFrame = SpellBookFrame
+local FriendsFrame = FriendsFrame
 
 local HasPetUI = HasPetUI
 
@@ -195,7 +199,11 @@ function DataToColor:Bits3()
         (LootFrame:IsShown() and 2 or 0) ^ 8 +
         (DataToColor:IsChatInputActive() and 2 or 0) ^ 9 +
         (DataToColor:SoftTargetInteractEnabled() and 2 or 0) ^ 10 +
-        (MailFrame:IsShown() and 2 or 0) ^ 11
+        (MailFrame:IsShown() and 2 or 0) ^ 11 +
+        (DataToColor:AnyBagOpen() and 2 or 0) ^ 12 +
+        (DataToColor:CharacterFrameOpen() and 2 or 0) ^ 13 +
+        (DataToColor:SpellBookFrameOpen() and 2 or 0) ^ 14 +
+        (DataToColor:FriendsFrameOpen() and 2 or 0) ^ 15
 end
 
 function DataToColor:CustomTrigger(t)
@@ -654,6 +662,27 @@ end
 function DataToColor:SoftTargetInteractEnabled()
     local success, value = pcall(GetCVar, DataToColor.C.CVarSoftTargetInteract)
     return success and tonumber(value) == 3
+end
+
+function DataToColor:AnyBagOpen()
+    for i = 0, NUM_BAG_SLOTS do
+        if IsBagOpen(i) then
+            return true
+        end
+    end
+    return false
+end
+
+function DataToColor:CharacterFrameOpen()
+    return CharacterFrame and CharacterFrame:IsShown() or false
+end
+
+function DataToColor:SpellBookFrameOpen()
+    return SpellBookFrame and SpellBookFrame:IsShown() or false
+end
+
+function DataToColor:FriendsFrameOpen()
+    return FriendsFrame and FriendsFrame:IsShown() or false
 end
 
 -- Returns true if target of our target is us

--- a/BlazorServer/appsettings.json
+++ b/BlazorServer/appsettings.json
@@ -24,7 +24,7 @@
   },
   "Reader": {
     "Type": "DXGI",
-    "UseGpu": true
+    "UseGpu": false
   },
   "Diagnostics": {
     "Enabled": false

--- a/BlazorServer/run.bat
+++ b/BlazorServer/run.bat
@@ -1,5 +1,5 @@
 start "" "http://localhost:5000"
 cd /D "%~dp0"
-dotnet run --configuration Release --no-build -- --Reader:Type=%~1
+dotnet run --configuration Release --no-build -- --Reader:Type=%~1 --Pathing:Mode=%~2 --Reader:UseGpu=%~3
 
 pause

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,9 @@ dotnet run --project Benchmarks -c Release
   - Replace magic strings/numbers with `public const` fields for cross-file discoverability
   - Place constants in the owning class to enable Find All References and compile-time safety
 
+## User facing API changes
+- When the `Core\Requirement\RequirementFactory.cs` is changed, a user facing API is added, removed, renamed make sure to update the `README.md` file
+
 ## Performance Guidelines
 Follow .NET performance best practices from:
 - https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-10/
@@ -85,6 +88,15 @@ Central package management via `Directory.Packages.props`:
 ## DataToColor WoW Addon (Lua 5.1)
 
 **Location:** `Addons/DataToColor/`
+
+### Addon version tracking
+
+In order to provide easy way for the user to receive addon changes we keep track of each addon change in a Pull Request. The pull request title starts with "Addon: [x.y.z] - TITLE"
+
+When a change happens in the *.lua files make sure to bump the patch version (if not changed already) in the following files
+* `Addons\DataToColor\DataToColor_TBC.toc`
+* `Addons\DataToColor\DataToColor.toc`
+* `Addons\DataToColor\DataToColor_Classic.toc`
 
 World of Warcraft uses **Lua 5.1** (all versions including Classic). The addon encodes game state as pixel colors for external reading.
 
@@ -221,6 +233,7 @@ Addons/DataToColor/
 ├── DataToColor.lua       - Main frame update loop (performance critical)
 ├── Constants.lua         - Static data tables
 ├── Query.lua             - Game state queries
+├── BitCache.lua          - Cache for Query.lua avoid excessive amount of wow lua api calls.
 ├── Storage.lua           - Data storage structures
 ├── EventHandlers.lua     - WoW event handling
 ├── Collections.lua       - Data structure implementations
@@ -228,3 +241,7 @@ Addons/DataToColor/
 ├── ActionBarMacros.lua   - Macro detection
 └── libs/                 - Ace3 libraries (external, don't modify)
 ```
+
+### Use event driven change tracking
+Use Event driven change tracking in the addon instead of polling the state each time.
+The lua Events should be handled in `EventHandlers.lua`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # WowClassicGrindBot - Claude Code Guidelines
 
+## bash commands
+* don't pipe to /dev/nul. we run git bash on windows and it doesn't work.
+* in case the file exists use `rm -f "./WowClassicGrindBot/nul"`
+
 ## Project Overview
 Multi-project .NET 10 solution (MasterOfPuppets.sln) with Blazor Server frontend, SignalR communication, and various utility projects.
 

--- a/Core/Addon/SpellBookReader.cs
+++ b/Core/Addon/SpellBookReader.cs
@@ -54,7 +54,7 @@ public sealed class SpellBookReader : IReader
 
     public bool Has(int id)
     {
-        return spells.Contains(id) || spellNames.Contains(SpellDB.Spells[id].Name);
+        return spells.Contains(id) || (SpellDB.Spells.TryGetValue(id, out Spell spell) && spellNames.Contains(spell.Name));
     }
 
     public bool TryGetValue(int id, out Spell spell)

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -116,4 +116,12 @@ public sealed class AddonBits : IReader, IGameMenuWindowShown
     public bool MailFrameShown() => v3[Mask._11];
 
     public bool NotMailFrameShown() => !MailFrameShown();
+
+    public bool AnyBagOpen() => v3[Mask._12];
+
+    public bool CharacterFrameOpen() => v3[Mask._13];
+
+    public bool SpellBookFrameOpen() => v3[Mask._14];
+
+    public bool FriendsFrameOpen() => v3[Mask._15];
 }

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -46,6 +46,7 @@ public sealed partial class ClassConfiguration
     public bool UseMount { get; set; } = true;
     public bool KeyboardOnly { get; set; }
     public bool AllowPvP { get; set; }
+    public bool TargetNeutral { get; set; }
     public bool AutoPetAttack { get; set; } = true;
 
     // Keeping this for backward compatibility

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -38,7 +38,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
 
     private readonly IBlacklist targetBlacklist;
     private readonly TargetFinder targetFinder;
-    private const NpcNames NpcNameToFind = NpcNames.Enemy | NpcNames.Neutral;
+    private readonly NpcNames npcNameToFind;
 
     private const int MIN_TIME_TO_START_CYCLE_PROFESSION = 5000;
     private const int CYCLE_PROFESSION_PERIOD = 8000;
@@ -105,6 +105,10 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
         this.mountHandler = mountHandler;
         this.targetFinder = targetFinder;
         this.targetBlacklist = targetBlacklist;
+
+        npcNameToFind = classConfig.TargetNeutral
+            ? NpcNames.Enemy | NpcNames.Neutral
+            : NpcNames.Enemy;
 
         if (pathSettings.Requirements.Count > 0)
         {
@@ -272,7 +276,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
         while (!sideActivityCts.IsCancellationRequested)
         {
             if (pathSettings.CanRunSideActivity() &&
-                targetFinder.Search(NpcNameToFind, bits.Target_NotDead, sideActivityCts.Token))
+                targetFinder.Search(npcNameToFind, bits.Target_NotDead, sideActivityCts.Token))
             {
                 if (bits.Target() && targetBlacklist.Is())
                 {

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -120,7 +120,11 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
         if (requiresNpcNameFinder)
         {
-            npcNameTargeting.ChangeNpcType(NpcNames.Enemy);
+            NpcNames npcTypes = NpcNames.Enemy;
+            if (classConfig.TargetNeutral)
+                npcTypes |= NpcNames.Neutral;
+
+            npcNameTargeting.ChangeNpcType(npcTypes);
         }
 
         pullStart = GetTimestamp();

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -132,7 +132,7 @@ public sealed partial class RequirementFactory
             { "Form", CreateForm },
             { "Race", CreateRace },
             { "Equipment:", CreateEquipment },
-            { "Spell", CreateSpell },
+            { "Spell:", CreateSpell },
             { "Talent", CreateTalent },
             { "Trigger:", CreateTrigger },
             { "Usable:", CreateUsable },

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -199,6 +199,10 @@ public sealed partial class RequirementFactory
 
             { "MenuOpen", bits.GameMenuWindowShown },
             { "ChatInputVisible", bits.ChatInputIsVisible },
+            { "AnyBagOpen", bits.AnyBagOpen },
+            { "CharacterFrameOpen", bits.CharacterFrameOpen },
+            { "SpellBookFrameOpen", bits.SpellBookFrameOpen },
+            { "FriendsFrameOpen", bits.FriendsFrameOpen },
 
             // Corpse-based abilities
             { "CannibalizeCorpse", CannibalizeCorpseNearby },

--- a/Core/WoWScreen/GpuLineSegmentProvider.cs
+++ b/Core/WoWScreen/GpuLineSegmentProvider.cs
@@ -103,6 +103,12 @@ public sealed class GpuLineSegmentProvider : IConfigurableLineSegmentProvider, I
         {
             return ExecuteGpu(capturedTexture, area, minLength, minEndLength);
         }
+        catch (Exception ex) when (IsDeviceRemoved())
+        {
+            permanentFallback = true;
+            logger.LogError(ex, "[GpuLineSegmentProvider] GPU device removed — permanent CPU fallback");
+            return cpuFallback.GetLineSegments(area, minLength, minEndLength);
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "[GpuLineSegmentProvider] GPU dispatch failed, falling back to CPU for {Frames} frames", FALLBACK_COOLDOWN);
@@ -316,6 +322,12 @@ public sealed class GpuLineSegmentProvider : IConfigurableLineSegmentProvider, I
                 cb.FuzzSqr4 = fuzzSqr;
                 break;
         }
+    }
+
+    private bool IsDeviceRemoved()
+    {
+        try { return !gpuProvider.Device.DeviceRemovedReason.Success; }
+        catch { return true; }
     }
 
     public void Dispose()

--- a/Core/WoWScreen/WowScreenDXGI.cs
+++ b/Core/WoWScreen/WowScreenDXGI.cs
@@ -18,6 +18,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
@@ -77,12 +78,23 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
     private readonly bool windowedMode;
     private bool deviceRemoved;
 
-    // IGpuTextureProvider
+    // IGpuTextureProvider -- Default-usage copy of client area for GPU compute shader
     private ID3D11Texture2D? lastCapturedTexture;
+    private readonly Lock gpuTextureLock = new();
+    private ID3D11Texture2D? gpuTextureCopy;
+    private int gpuTextureWidth;
+    private int gpuTextureHeight;
 
     ID3D11Device IGpuTextureProvider.Device => device;
     ID3D11DeviceContext IGpuTextureProvider.DeviceContext => device.ImmediateContext;
-    ID3D11Texture2D? IGpuTextureProvider.GetCapturedTexture() => lastCapturedTexture;
+
+    ID3D11Texture2D? IGpuTextureProvider.GetCapturedTexture()
+    {
+        using (gpuTextureLock.EnterScope())
+        {
+            return gpuTextureCopy;
+        }
+    }
 
     // IAddonDataProvider
 
@@ -143,10 +155,15 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
 
         output1 = output.QueryInterface<IDXGIOutput1>();
         result = D3D11.D3D11CreateDevice(adapter, DriverType.Unknown,
-            DeviceCreationFlags.Singlethreaded, s_featureLevels, out device!);
+            DeviceCreationFlags.None, s_featureLevels, out device!);
 
         if (result == Result.Fail)
             throw new Exception($"device is null {result.Description}");
+
+        using (ID3D11Multithread multithread = device.QueryInterface<ID3D11Multithread>())
+        {
+            multithread.SetMultithreadProtected(true);
+        }
 
         duplication = output1.DuplicateOutput(device);
 
@@ -192,6 +209,7 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
         try { duplication?.ReleaseFrame(); } catch { }
         try { duplication?.Dispose(); } catch { }
 
+        try { gpuTextureCopy?.Dispose(); } catch { }
         try { lastCapturedTexture?.Dispose(); } catch { }
         try { minimapTexture.Dispose(); } catch { }
         try { addonTexture.Dispose(); } catch { }
@@ -288,6 +306,39 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
 
             lastCapturedTexture?.Dispose();
             lastCapturedTexture = texture;
+
+            // Copy client area to GPU texture for compute shader
+            // (desktop duplication captures the full monitor; the shader uses
+            //  0-based coordinates relative to the client area)
+            using (gpuTextureLock.EnterScope())
+            {
+                if (gpuTextureCopy == null ||
+                    gpuTextureWidth != screenRect.Width ||
+                    gpuTextureHeight != screenRect.Height)
+                {
+                    ID3D11Texture2D? oldTexture = gpuTextureCopy;
+                    gpuTextureCopy = device.CreateTexture2D(new Texture2DDescription
+                    {
+                        Width = (uint)screenRect.Width,
+                        Height = (uint)screenRect.Height,
+                        MipLevels = 1,
+                        ArraySize = 1,
+                        Format = Format.B8G8R8A8_UNorm,
+                        SampleDescription = new(1, 0),
+                        Usage = ResourceUsage.Default,
+                        BindFlags = BindFlags.ShaderResource
+                    });
+                    gpuTextureWidth = screenRect.Width;
+                    gpuTextureHeight = screenRect.Height;
+                    oldTexture?.Dispose();
+                }
+            }
+
+            Box gpuBox = new(
+                screenRect.X, screenRect.Y, 0,
+                screenRect.Right, screenRect.Bottom, 1);
+            device.ImmediateContext.CopySubresourceRegion(
+                gpuTextureCopy, 0, 0, 0, 0, texture, 0, gpuBox);
 
             if (frames.Length > 2)
                 UpdateAddonImage(texture);

--- a/Core/WoWScreen/WowScreenDXGI.cs
+++ b/Core/WoWScreen/WowScreenDXGI.cs
@@ -75,6 +75,7 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
     private readonly IDXGIOutputDuplication duplication;
 
     private readonly bool windowedMode;
+    private bool deviceRemoved;
 
     // IGpuTextureProvider
     private ID3D11Texture2D? lastCapturedTexture;
@@ -242,6 +243,9 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
     [SkipLocalsInit]
     public void Update()
     {
+        if (deviceRemoved)
+            return;
+
         if (windowedMode)
         {
             GetRectangle(out screenRect);
@@ -254,7 +258,14 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
                 return;
         }
 
-        duplication.ReleaseFrame();
+        try
+        {
+            duplication.ReleaseFrame();
+        }
+        catch (SharpGenException) when (CheckDeviceRemoved())
+        {
+            return;
+        }
 
         Result result = duplication.AcquireNextFrame(5,
             out OutduplFrameInfo frame,
@@ -270,20 +281,41 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureP
             return;
         }
 
-        ID3D11Texture2D texture
-            = idxgiResource.QueryInterface<ID3D11Texture2D>();
+        try
+        {
+            ID3D11Texture2D texture
+                = idxgiResource.QueryInterface<ID3D11Texture2D>();
 
-        lastCapturedTexture?.Dispose();
-        lastCapturedTexture = texture;
+            lastCapturedTexture?.Dispose();
+            lastCapturedTexture = texture;
 
-        if (frames.Length > 2)
-            UpdateAddonImage(texture);
+            if (frames.Length > 2)
+                UpdateAddonImage(texture);
 
-        if (Enabled)
-            UpdateScreenImage(texture);
+            if (Enabled)
+                UpdateScreenImage(texture);
 
-        if (MinimapEnabled)
-            UpdateMinimapImage(texture);
+            if (MinimapEnabled)
+                UpdateMinimapImage(texture);
+        }
+        catch (SharpGenException) when (CheckDeviceRemoved())
+        {
+            // Device lost — silently stop capturing
+        }
+    }
+
+    private bool CheckDeviceRemoved()
+    {
+        try
+        {
+            if (device.DeviceRemovedReason.Success)
+                return false;
+        }
+        catch { }
+
+        deviceRemoved = true;
+        logger.LogError("GPU device removed (DXGI_ERROR_DEVICE_REMOVED). Screen capture disabled. Restart the bot to recover.");
+        return true;
     }
 
     [SkipLocalsInit]

--- a/Core/WoWScreen/WowScreenWGC.cs
+++ b/Core/WoWScreen/WowScreenWGC.cs
@@ -52,7 +52,7 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
     public event Action? OnChanged;
 
     public bool Enabled { get => true; set { } }
-    public bool EnablePostProcess { get; set; } = true;
+    public bool EnablePostProcess { get => true; set { } }
     public bool MinimapEnabled { get; set; }
 
     public Rectangle ScreenRect => screenRect;

--- a/Core/WoWScreen/WowScreenWGC.cs
+++ b/Core/WoWScreen/WowScreenWGC.cs
@@ -51,7 +51,7 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
 
     public event Action? OnChanged;
 
-    public bool Enabled { get; set; } = true;
+    public bool Enabled { get => true; set { } }
     public bool EnablePostProcess { get; set; } = true;
     public bool MinimapEnabled { get; set; }
 

--- a/Core/WoWScreen/WowScreenWGC.cs
+++ b/Core/WoWScreen/WowScreenWGC.cs
@@ -7,6 +7,8 @@ using Game;
 
 using Microsoft.Extensions.Logging;
 
+using SharpGen.Runtime;
+
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.PixelFormats;
@@ -90,6 +92,8 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
     private GraphicsCaptureItem? captureItem;
     private Direct3D11CaptureFramePool? framePool;
     private GraphicsCaptureSession? captureSession;
+
+    private bool deviceRemoved;
 
     // Double-buffer: WGC writes async, Update() reads
     private readonly Lock frameLock = new();
@@ -371,6 +375,9 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
     [SkipLocalsInit]
     public void Update()
     {
+        if (deviceRemoved)
+            return;
+
         // Get latest window rect
         GetRectangle(out Rectangle newRect);
 
@@ -422,6 +429,10 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
                 deviceContext.Unmap(frameToProcess, 0);
             }
         }
+        catch (SharpGenException) when (CheckDeviceRemoved())
+        {
+            // Device lost — silently stop capturing
+        }
         finally
         {
             using (frameLock.EnterScope())
@@ -458,6 +469,20 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
         }
     }
 #endif
+
+    private bool CheckDeviceRemoved()
+    {
+        try
+        {
+            if (device.DeviceRemovedReason.Success)
+                return false;
+        }
+        catch { }
+
+        deviceRemoved = true;
+        logger.LogError("GPU device removed (DXGI_ERROR_DEVICE_REMOVED). Screen capture disabled. Restart the bot to recover.");
+        return true;
+    }
 
     private void RecreateFramePool()
     {

--- a/Core/WoWScreen/WowScreenWGC.cs
+++ b/Core/WoWScreen/WowScreenWGC.cs
@@ -110,7 +110,14 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
 
     ID3D11Device IGpuTextureProvider.Device => device;
     ID3D11DeviceContext IGpuTextureProvider.DeviceContext => deviceContext;
-    ID3D11Texture2D? IGpuTextureProvider.GetCapturedTexture() => gpuTextureCopy;
+
+    ID3D11Texture2D? IGpuTextureProvider.GetCapturedTexture()
+    {
+        using (frameLock.EnterScope())
+        {
+            return gpuTextureCopy;
+        }
+    }
 
     // Client area offset (WGC captures full window including title bar)
     private Point clientOffset;
@@ -144,6 +151,11 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
             out device!);
 
         deviceContext = device.ImmediateContext;
+
+        using (ID3D11Multithread multithread = device.QueryInterface<ID3D11Multithread>())
+        {
+            multithread.SetMultithreadProtected(true);
+        }
 
         // Create WinRT device for WGC
         winrtDevice = GraphicsCaptureInterop.CreateDirect3DDeviceFromD3D11(device)
@@ -247,35 +259,43 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTexturePr
 
                 // Copy client area only to GPU texture for compute shader
                 // (WGC captures full window including title bar; match CPU path)
-                if (gpuTextureCopy == null ||
-                    gpuTextureSize.Width != screenRect.Width ||
-                    gpuTextureSize.Height != screenRect.Height)
+                // Clamp to frame content bounds to avoid out-of-bounds copy
+                // during window resize or DPI changes
+                int gpuCopyWidth = Math.Min(screenRect.Width, contentSize.Width - clientOffset.X);
+                int gpuCopyHeight = Math.Min(screenRect.Height, contentSize.Height - clientOffset.Y);
+
+                if (gpuCopyWidth > 0 && gpuCopyHeight > 0)
                 {
-                    gpuTextureCopy?.Dispose();
-
-                    Texture2DDescription gpuDesc = frameTexture.Description;
-                    gpuDesc.Width = (uint)screenRect.Width;
-                    gpuDesc.Height = (uint)screenRect.Height;
-                    gpuDesc.Usage = ResourceUsage.Default;
-                    gpuDesc.BindFlags = BindFlags.ShaderResource;
-                    gpuDesc.CPUAccessFlags = CpuAccessFlags.None;
-                    gpuDesc.MiscFlags = ResourceOptionFlags.None;
-
-                    gpuTextureCopy = device.CreateTexture2D(gpuDesc);
-                    gpuTextureSize = new SizeInt32
+                    if (gpuTextureCopy == null ||
+                        gpuTextureSize.Width != gpuCopyWidth ||
+                        gpuTextureSize.Height != gpuCopyHeight)
                     {
-                        Width = screenRect.Width,
-                        Height = screenRect.Height
-                    };
-                }
+                        Texture2DDescription gpuDesc = frameTexture.Description;
+                        gpuDesc.Width = (uint)gpuCopyWidth;
+                        gpuDesc.Height = (uint)gpuCopyHeight;
+                        gpuDesc.Usage = ResourceUsage.Default;
+                        gpuDesc.BindFlags = BindFlags.ShaderResource;
+                        gpuDesc.CPUAccessFlags = CpuAccessFlags.None;
+                        gpuDesc.MiscFlags = ResourceOptionFlags.None;
 
-                Box clientBox = new(
-                    clientOffset.X, clientOffset.Y, 0,
-                    clientOffset.X + screenRect.Width,
-                    clientOffset.Y + screenRect.Height, 1);
-                deviceContext.CopySubresourceRegion(
-                    gpuTextureCopy, 0, 0, 0, 0,
-                    frameTexture, 0, clientBox);
+                        ID3D11Texture2D? oldGpuTexture = gpuTextureCopy;
+                        gpuTextureCopy = device.CreateTexture2D(gpuDesc);
+                        gpuTextureSize = new SizeInt32
+                        {
+                            Width = gpuCopyWidth,
+                            Height = gpuCopyHeight
+                        };
+                        oldGpuTexture?.Dispose();
+                    }
+
+                    Box clientBox = new(
+                        clientOffset.X, clientOffset.Y, 0,
+                        clientOffset.X + gpuCopyWidth,
+                        clientOffset.Y + gpuCopyHeight, 1);
+                    deviceContext.CopySubresourceRegion(
+                        gpuTextureCopy, 0, 0, 0, 0,
+                        frameTexture, 0, clientBox);
+                }
 
                 // Only swap if Update() isn't actively reading from readStagingTexture.
                 // If processingFrame is true, we just overwrote writeStagingTexture in place

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -70,11 +70,11 @@ internal sealed class Program
         //screen = new WowScreenDXGI(loggerFactory.CreateLogger<WowScreenDXGI>(), process, mockFrames);
         screen = new WowScreenWGC(loggerFactory.CreateLogger<WowScreenWGC>(), process, mockFrames);
 
-        //Test_NPCNameFinder();
+        Test_NPCNameFinder();
         //Test_Input();
         //Test_CursorGrabber();
         //Test_CursorCompare();
-        Test_MinimapNodeFinder();
+        //Test_MinimapNodeFinder();
         //Test_FindTargetByCursor();
 
         Log.CloseAndFlush();

--- a/HeadlessServer/RunOptions.cs
+++ b/HeadlessServer/RunOptions.cs
@@ -30,8 +30,9 @@ public sealed class RunOptions
         "reader",
         Required = false,
         Default = AddonDataProviderType.DXGI,
-        HelpText = $"Screen reader backend." +
-        $"'{nameof(AddonDataProviderType.DXGI)}': DirectX based works from Win8.")]
+        HelpText = $"Screen reader backend. " +
+        $"'{nameof(AddonDataProviderType.DXGI)}': DirectX based, works from Win8. " +
+        $"'{nameof(AddonDataProviderType.WGC)}': Windows Graphics Capture, supports background capture (Win10 2004+).")]
     public AddonDataProviderType Reader { get; set; }
 
     [Option("hostv1",

--- a/HeadlessServer/RunOptions.cs
+++ b/HeadlessServer/RunOptions.cs
@@ -96,7 +96,7 @@ public sealed class RunOptions
 
     [Option('g', "gpu",
         Required = false,
-        Default = true,
+        Default = false,
         HelpText = "Use GPU compute shader for NPC name finding")]
     public bool UseGpu { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -99,140 +99,6 @@ V1 Local and V1 Remote does not have the capability as of this moment to read th
 - Added Skinning Goal -> `GatherCorpse` (Skin, Herb, Mine, Salvage)
 - Introduced a concept of `Produce`/`Consume` corpses. Killing multiple enemies in a single combat can consume them all.
 
-## Mail Feature
-
-Automatically mail items and gold to another character when visiting a mailbox.
-
-### Quick Setup
-
-1. Enable mail in your class profile:
-```json
-{
-  "Mail": true,
-  "MailConfig": {
-    "RecipientName": "YourAltCharacter"
-  }
-}
-```
-
-2. The bot will mail items after vendoring/repairing when:
-   - Items meet the quality threshold (default: Green/Uncommon)
-   - Player has excess gold above minimum threshold
-   - Player is at a mailbox
-
-### Configuration Options
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `Mail` | bool | `false` | Enable/disable mail for this profile |
-| `MailFilename` | string | `""` | External mail config file (relative to `Json/mail/`) |
-| `MailConfig.RecipientName` | string | `""` | Character name to send mail to |
-| `MailConfig.MinimumGoldToKeep` | int | `10000` | Minimum gold to keep (in copper, 10000 = 1g) |
-| `MailConfig.MinimumItemQuality` | int | `2` | Minimum item quality (0=Grey, 1=White, 2=Green, 3=Blue, 4=Epic) |
-| `MailConfig.SendGold` | bool | `true` | Whether to send excess gold |
-| `MailConfig.SendItems` | bool | `true` | Whether to send items |
-| `MailConfig.ExcludedItemIds` | int[] | `[]` | Item IDs to never mail |
-
-### Recipient Priority
-
-The recipient is determined in this order:
-1. **UI Setting** (localStorage) - Set via Frontend Mail page
-2. **Environment Variable** - `MAIL_RECIPIENT=CharacterName`
-3. **JSON Config** - `MailConfig.RecipientName`
-
-### Special Recipient Keywords
-
-Instead of a character name, you can use special keywords:
-
-| Keyword | Behavior |
-|---------|----------|
-| `UseRandomFriendList` | Randomly selects a character from your friend list (online or offline) |
-
-**Example:**
-```json
-{
-  "Mail": true,
-  "MailConfig": {
-    "RecipientName": "UseRandomFriendList",
-    "MinimumItemQuality": 2
-  }
-}
-```
-
-**Note:** If using `UseRandomFriendList` and your friend list is empty, mail sending will be skipped.
-
-### Example: Full Mail Configuration
-
-```json
-{
-  "ClassName": "Warrior",
-  "Mail": true,
-  "MailConfig": {
-    "RecipientName": "MyBankAlt",
-    "MinimumGoldToKeep": 50000,
-    "MinimumItemQuality": 2,
-    "SendGold": true,
-    "SendItems": true,
-    "ExcludedItemIds": [6948, 5956, 4306]
-  }
-}
-```
-
-### Example: Using External Config File
-
-```json
-{
-  "Mail": true,
-  "MailFilename": "bank_alt_mail.json"
-}
-```
-
-Create `Json/mail/bank_alt_mail.json`:
-```json
-{
-  "RecipientName": "MyBankAlt",
-  "MinimumGoldToKeep": 20000,
-  "MinimumItemQuality": 1,
-  "SendGold": true,
-  "SendItems": true,
-  "ExcludedItemIds": [6948]
-}
-```
-
-### Item Quality Reference
-
-| Value | Quality | Color |
-|-------|---------|-------|
-| 0 | Poor | Grey |
-| 1 | Common | White |
-| 2 | Uncommon | Green |
-| 3 | Rare | Blue |
-| 4 | Epic | Purple |
-| 5 | Legendary | Orange |
-
-### What Gets Mailed
-
-**Mailed:**
-- Items meeting quality threshold
-- Not in excluded items list
-- Tradable (not soulbound, not quest items)
-
-**Never Mailed:**
-- Soulbound items
-- Quest items
-- Bind-on-Pickup (BoP) items
-- Items in exclusion list
-- Hearthstone (recommended to exclude: 6948)
-
-### Frontend Mail Page
-
-The Mail page in the browser UI allows you to:
-- Set recipient name (persists across sessions)
-- Configure quality threshold and gold minimum
-- Visually browse your inventory
-- Click items to add/remove from exclusion list
-- Save settings to profile or use runtime overrides
-
 ## Additional Features
 
 - Corpse run
@@ -283,59 +149,6 @@ The Mail page in the browser UI allows you to:
 <a href="https://mega.nz/file/KDRiCAzI#DamyH3QCha8vm4qfhqVYRb6ffbkhvfyZxWhz9D1OKEc" target="_blank">
    <img alt="Death Knight 2" src="https://i.imgur.com/3nXwSoy.jpeg" width="50%">
 </a>
-
-# Important: Migration Guide for Existing Users
-
-If you are upgrading from a previous version, please read this section carefully.
-
-## Breaking Changes
-
-### Keybinding System Overhaul
-
-The application now **automatically reads your in-game keybindings** instead of requiring manual configuration. This is a significant improvement but requires some migration steps.
-
-**What Changed:**
-1. The addon now sends your actual WoW keybindings to the application
-2. Modifier keys (Shift, Ctrl, Alt) are now fully supported
-3. BindPad addon is bundled and used internally for secure macro buttons
-4. Custom actions (StopAttack, ClearTarget) now use Alt-modified keys by default
-
-**Migration Steps:**
-
-1. **Update the Addon**: Copy the new `DataToColor` addon to your WoW Addons folder, replacing the old version.
-
-2. **Install BindPad**: Copy the `BindPad` addon from the `Addons/BindPad/` folder to your WoW Addons folder. This is required for TBC Classic 2.5.5+ compatibility.
-
-3. **First Login**: On first login after the update, the addon will:
-   - Automatically set up essential keybindings if they are missing
-   - Create secure action buttons for StopAttack, ClearTarget, etc.
-   - Read and send all your keybindings to the application
-
-4. **Check Your Class Profile**: The default keys for some BaseActions have changed:
-   | Action | Old Default | New Default |
-   | --- | --- | --- |
-   | Interact | `I` | `Alt-Home` |
-   | InteractMouseOver | `J` | `Alt-End` |
-   | ClearTarget | `Insert` | `Alt-Insert` |
-   | StopAttack | `Delete` | `Alt-Delete` |
-   | TargetFocus | `PageUp` | `Alt-PageUp` |
-   | FollowTarget | `PageDown` | `Alt-PageDown` |
-
-   If your class profile overrides these keys, you may need to update them.
-
-5. **In-Game Verification**: After logging in, you can verify the bindings are working:
-   - Press `Shift-PageUp` to toggle addon config mode (should see "Config mode" / "Normal mode" messages)
-   - Press `Shift-PageDown` to flush addon state (should see "Flush State" message)
-
-### Troubleshooting
-
-If bindings are not working after migration:
-1. Make sure you are not in combat when logging in (bindings cannot be set in combat)
-2. Run `/<prefix>actions` to manually create and bind the custom actions (e.g., `/dcactions`)
-3. Run `/<prefix>bindings` to set up default action bar bindings (e.g., `/dcbindings`)
-4. Check the Frontend "Key Bindings" page to see what bindings the addon detected
-
-**Note**: The command prefix (e.g., `dc`) is derived from your addon title. If you named your addon "daq" during setup, use `/daqactions`, `/daqbindings`, etc.
 
 # Issues and Ideas
 
@@ -442,7 +255,21 @@ For Nvidia users, under Nvidia Control panel settings
 Known issues with other applications:
 * `f.lux` can affect final image color on the screen thus prevents NpcNameFinder to work properly.
 
-## 3.2 In-game Requirements
+## 3.2 Screen Capture Methods
+
+The bot supports two screen capture backends:
+
+| Feature | DXGI | WGC |
+|---------|------|-----|
+| **Minimum Windows** | Windows 8+ | Windows 10 2004 (build 19041+) |
+| **Background capture** | No — game window must be uncovered | Yes — works behind other windows |
+| **Borderless capture** | N/A | Yes (build 20348+, no yellow border) |
+| **Default** | Yes | No (opt-in via `--reader WGC`) |
+| **GPU compute support** | Yes | Yes |
+
+DXGI is the default and most compatible. Use WGC if you want to capture the game window while it's behind other windows (requires Win10 2004+). If WGC is requested but unsupported, the application automatically falls back to DXGI.
+
+## 3.3 In-game Requirements
 
 Required game client settings. Press `ESC` -> `System`
   * System > Graphics > Anti-Aliasing: `None`
@@ -454,7 +281,7 @@ Required game client settings. Press `ESC` -> `System`
   * Disable Glow effect - type in the chat `/console ffxGlow 0`
   * To keep/save this settings make sure to properly shutdown the game.
 
-## 3.3 Optional - Replace default game Font
+## 3.4 Optional - Replace default game Font
 
 Highly recommended to replace the default in-game font with a much **Bolder** one with [this guide](https://classic.wowhead.com/guides/changing-wow-text-font)
 
@@ -462,7 +289,7 @@ Should be only concerned about `Friz Quadrata: the "Everything Else" Font` which
 
 Example - [Robot-Medium](https://fonts.google.com/specimen/Roboto?thickness=5) - Shows big improvement to the `NpcNameFinder` component which is responsible to find - friendly, enemy, corpse - names above NPCs head.
 
-## 3.4 Optional - Enable Minimum Character Name Size
+## 3.5 Optional - Enable Minimum Character Name Size
 
 In the modern client under ESC > Options > Accessibility > General > **Minimum Character Name Size = 6**
 
@@ -561,7 +388,7 @@ For normal quick startup of `HeadlessServer` please look at the `HeadlessServer\
 | ---- | ---- | ---- | ---- |
 | `-m`<br>`-mode` | Pathfinder type | `RemoteV3` | `Local` or `RemoteV1` or `RemoteV3` |
 | `-p`<br>`-pid` | World of Warcraft process id | `-1` | open up task manager to find PID |
-| `-r`<br>`-reader` | Addon data screen reader backend | `DXGI` | `DXGI` works since Win8 |
+| `-r`<br>`-reader` | Addon data screen reader backend | `DXGI` | `DXGI` or `WGC`. See [Screen Capture Methods](#32-screen-capture-methods) |
 | `hostv1` | Navigation Remote V1 host | `localhost` | - |
 | `portv1` | Navigation Remote V1 port | `5001` | - |
 | `hostv3` | Navigation Remote V3 host | `127.0.0.1` | - |
@@ -860,7 +687,7 @@ The class configuration controls all aspects of bot behavior. Here's why each se
 | --- | --- | --- | --- |
 | `"Mail"` | Enable mail functionality | true | `false` |
 | `"MailFilename"` | External mail config file path (relative to `Json/mail/`) | true | `""` |
-| `"MailConfig"` | Inline mail configuration object. See [Mail Feature](#mail-feature) | true | `{}` |
+| `"MailConfig"` | Inline mail configuration object. See [Mail Goal](#mail-goal) | true | `{}` |
 | --- | --- | --- | --- |
 | `"GatherFindKeys"` | List of strings for switching between gathering profiles | true | `string[]` |
 | --- | --- | --- | --- |
@@ -1261,6 +1088,140 @@ From Addon version **1.6.0** it has been significantly changed to the point wher
 As a result in order to execute the [Pull Goal](#pull-goal) sequence in respect, have to combine its [KeyAction(s)](#keyaction) with `AfterCast` prefixed conditions.
 
 ---
+
+## Mail Goal
+
+Automatically mail items and gold to another character when visiting a mailbox.
+
+### Quick Setup
+
+1. Enable mail in your class profile:
+```json
+{
+  "Mail": true,
+  "MailConfig": {
+    "RecipientName": "YourAltCharacter"
+  }
+}
+```
+
+2. The bot will mail items after vendoring/repairing when:
+   - Items meet the quality threshold (default: Green/Uncommon)
+   - Player has excess gold above minimum threshold
+   - Player is at a mailbox
+
+### Configuration Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Mail` | bool | `false` | Enable/disable mail for this profile |
+| `MailFilename` | string | `""` | External mail config file (relative to `Json/mail/`) |
+| `MailConfig.RecipientName` | string | `""` | Character name to send mail to |
+| `MailConfig.MinimumGoldToKeep` | int | `10000` | Minimum gold to keep (in copper, 10000 = 1g) |
+| `MailConfig.MinimumItemQuality` | int | `2` | Minimum item quality (0=Grey, 1=White, 2=Green, 3=Blue, 4=Epic) |
+| `MailConfig.SendGold` | bool | `true` | Whether to send excess gold |
+| `MailConfig.SendItems` | bool | `true` | Whether to send items |
+| `MailConfig.ExcludedItemIds` | int[] | `[]` | Item IDs to never mail |
+
+### Recipient Priority
+
+The recipient is determined in this order:
+1. **UI Setting** (localStorage) - Set via Frontend Mail page
+2. **Environment Variable** - `MAIL_RECIPIENT=CharacterName`
+3. **JSON Config** - `MailConfig.RecipientName`
+
+### Special Recipient Keywords
+
+Instead of a character name, you can use special keywords:
+
+| Keyword | Behavior |
+|---------|----------|
+| `UseRandomFriendList` | Randomly selects a character from your friend list (online or offline) |
+
+**Example:**
+```json
+{
+  "Mail": true,
+  "MailConfig": {
+    "RecipientName": "UseRandomFriendList",
+    "MinimumItemQuality": 2
+  }
+}
+```
+
+**Note:** If using `UseRandomFriendList` and your friend list is empty, mail sending will be skipped.
+
+### Example: Full Mail Configuration
+
+```json
+{
+  "ClassName": "Warrior",
+  "Mail": true,
+  "MailConfig": {
+    "RecipientName": "MyBankAlt",
+    "MinimumGoldToKeep": 50000,
+    "MinimumItemQuality": 2,
+    "SendGold": true,
+    "SendItems": true,
+    "ExcludedItemIds": [6948, 5956, 4306]
+  }
+}
+```
+
+### Example: Using External Config File
+
+```json
+{
+  "Mail": true,
+  "MailFilename": "bank_alt_mail.json"
+}
+```
+
+Create `Json/mail/bank_alt_mail.json`:
+```json
+{
+  "RecipientName": "MyBankAlt",
+  "MinimumGoldToKeep": 20000,
+  "MinimumItemQuality": 1,
+  "SendGold": true,
+  "SendItems": true,
+  "ExcludedItemIds": [6948]
+}
+```
+
+### Item Quality Reference
+
+| Value | Quality | Color |
+|-------|---------|-------|
+| 0 | Poor | Grey |
+| 1 | Common | White |
+| 2 | Uncommon | Green |
+| 3 | Rare | Blue |
+| 4 | Epic | Purple |
+| 5 | Legendary | Orange |
+
+### What Gets Mailed
+
+**Mailed:**
+- Items meeting quality threshold
+- Not in excluded items list
+- Tradable (not soulbound, not quest items)
+
+**Never Mailed:**
+- Soulbound items
+- Quest items
+- Bind-on-Pickup (BoP) items
+- Items in exclusion list
+- Hearthstone (recommended to exclude: 6948)
+
+### Frontend Mail Page
+
+The Mail page in the browser UI allows you to:
+- Set recipient name (persists across sessions)
+- Configure quality threshold and gold minimum
+- Visually browse your inventory
+- Click items to add/remove from exclusion list
+- Save settings to profile or use runtime overrides
 
 ## Goal Groups
 
@@ -3303,3 +3264,56 @@ Melee weapon enchant:
 **Q: Modifier keys (Shift/Ctrl/Alt) not working**
 - Only single modifiers are supported, not combinations like Shift-Alt
 - Verify the binding in WoW uses the same modifier
+
+# Important: Migration Guide for Existing Users
+
+If you are upgrading from a previous version, please read this section carefully.
+
+## Breaking Changes
+
+### Keybinding System Overhaul
+
+The application now **automatically reads your in-game keybindings** instead of requiring manual configuration. This is a significant improvement but requires some migration steps.
+
+**What Changed:**
+1. The addon now sends your actual WoW keybindings to the application
+2. Modifier keys (Shift, Ctrl, Alt) are now fully supported
+3. BindPad addon is bundled and used internally for secure macro buttons
+4. Custom actions (StopAttack, ClearTarget) now use Alt-modified keys by default
+
+**Migration Steps:**
+
+1. **Update the Addon**: Copy the new `DataToColor` addon to your WoW Addons folder, replacing the old version.
+
+2. **Install BindPad**: Copy the `BindPad` addon from the `Addons/BindPad/` folder to your WoW Addons folder. This is required for TBC Classic 2.5.5+ compatibility.
+
+3. **First Login**: On first login after the update, the addon will:
+   - Automatically set up essential keybindings if they are missing
+   - Create secure action buttons for StopAttack, ClearTarget, etc.
+   - Read and send all your keybindings to the application
+
+4. **Check Your Class Profile**: The default keys for some BaseActions have changed:
+   | Action | Old Default | New Default |
+   | --- | --- | --- |
+   | Interact | `I` | `Alt-Home` |
+   | InteractMouseOver | `J` | `Alt-End` |
+   | ClearTarget | `Insert` | `Alt-Insert` |
+   | StopAttack | `Delete` | `Alt-Delete` |
+   | TargetFocus | `PageUp` | `Alt-PageUp` |
+   | FollowTarget | `PageDown` | `Alt-PageDown` |
+
+   If your class profile overrides these keys, you may need to update them.
+
+5. **In-Game Verification**: After logging in, you can verify the bindings are working:
+   - Press `Shift-PageUp` to toggle addon config mode (should see "Config mode" / "Normal mode" messages)
+   - Press `Shift-PageDown` to flush addon state (should see "Flush State" message)
+
+### Troubleshooting
+
+If bindings are not working after migration:
+1. Make sure you are not in combat when logging in (bindings cannot be set in combat)
+2. Run `/<prefix>actions` to manually create and bind the custom actions (e.g., `/dcactions`)
+3. Run `/<prefix>bindings` to set up default action bar bindings (e.g., `/dcbindings`)
+4. Check the Frontend "Key Bindings" page to see what bindings the addon detected
+
+**Note**: The command prefix (e.g., `dc`) is derived from your addon title. If you named your addon "daq" during setup, use `/daqactions`, `/daqbindings`, etc.

--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ The class configuration controls all aspects of bot behavior. Here's why each se
 | `"Salvage"` | Should salvage the mob | true | `false` |
 | `"UseMount"` | Should use mount when its possible | true | `false` |
 | `"AllowPvP"` | Should engage combat with the opposite faction | true | `false` |
+| `"TargetNeutral"` | Should detect neutral (yellow) nameplates in addition to hostile (red). Enable for starting zones (levels 1-5) where mobs are neutral. | true | `false` |
 | `"AutoPetAttack"` | Should the pet start attacking as soon as possible | true | `true` |
 | `"KeyboardOnly"` | Use keyboard to interact only. See [KeyboardOnly](#keyboardonly) | false | `true` |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -2456,6 +2456,10 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"Flying"` | The player is currently flying, not touching the ground. |
 | `"MenuOpen"` | Returns true if the Game Menu window is open (ESC) |
 | `"ChatInputVisible"` | Returns true if the Chat inputbox is open (ENTER) |
+| `"AnyBagOpen"` | Returns true if any bag frame is visible on screen |
+| `"CharacterFrameOpen"` | Returns true if the Character Info window is open (C) |
+| `"SpellBookFrameOpen"` | Returns true if the Spellbook window is open (P) |
+| `"FriendsFrameOpen"` | Returns true if the Social/Friends window is open (O) |
 | `"Dead"` | The player is currently dead. |
 | `"CannibalizeCorpse"` | A Humanoid or Undead corpse is within 5 yards of the player. |
 | `"DamageTakenFromTotem"` | The player has taken damage from a Totem creature type. Useful to detect nearby totems. |

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+using static System.Diagnostics.Stopwatch;
+
 namespace SharedLib.NpcFinder;
 
 public sealed partial class NpcNameFinder
@@ -32,6 +34,8 @@ public sealed partial class NpcNameFinder
     private const float refWidth = 1920;
     private const float refHeight = 1080;
 
+    private const long RemoveAddThreatAfterMS = 1500;
+
     public readonly float ScaleToRefWidth = 1;
     public readonly float ScaleToRefHeight = 1;
 
@@ -49,7 +53,7 @@ public sealed partial class NpcNameFinder
     public bool PotentialAddsExist { get; private set; }
     public bool _PotentialAddsExist() => PotentialAddsExist;
 
-    public DateTime LastPotentialAddsSeen { get; private set; }
+    private long LastPotentialAddsSeen;
 
     private readonly NpcPositionComparer npcPosComparer;
 
@@ -174,12 +178,12 @@ public sealed partial class NpcNameFinder
         if (AddCount > 0 && TargetCount >= 1)
         {
             PotentialAddsExist = true;
-            LastPotentialAddsSeen = DateTime.UtcNow;
+            LastPotentialAddsSeen = GetTimestamp();
         }
         else
         {
             if (PotentialAddsExist &&
-                (DateTime.UtcNow - LastPotentialAddsSeen).TotalSeconds > 1)
+                GetElapsedTime(LastPotentialAddsSeen).TotalMilliseconds > RemoveAddThreatAfterMS)
             {
                 PotentialAddsExist = false;
                 AddCount = 0;

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -175,7 +175,7 @@ public sealed partial class NpcNameFinder
         TargetCount = Npcs.Count(TargetsCount);
         AddCount = Npcs.Count(IsAdd);
 
-        if (AddCount > 0 && TargetCount >= 1)
+        if (AddCount > 0)
         {
             PotentialAddsExist = true;
             LastPotentialAddsSeen = GetTimestamp();


### PR DESCRIPTION
Handle DXGI_ERROR_DEVICE_REMOVED gracefully instead of crash-looping on weak iGPUs (e.g. Intel HD Graphics 530). GpuLineSegmentProvider now permanently falls back to CPU on device removal instead of retrying every 100 frames. WowScreenDXGI and WowScreenWGC catch SharpGenException filtered by device removal status and disable capture with a single log error, preventing the AddonThread from being killed.